### PR TITLE
Make Heroku worker dyno autostart after deploy

### DIFF
--- a/app.json
+++ b/app.json
@@ -46,5 +46,10 @@
     "SUDOERS": {
 	    "description": "Users which have special control over the bot, Separated by space.",
 	    "required": true
-    }
+    },
+    "formation": {
+      "worker": {
+        "quantity": 1
+      }
+  }
 }}


### PR DESCRIPTION
## Problem
App doesnt autostart after deploying to heroku.

## Changes made to fix this
Edited app.json file and added formation worker in it to enable and start worker dyno automatically after the build succeeds and app deploys.

## Reference
https://devcenter.heroku.com/articles/app-json-schema#formation